### PR TITLE
feat(main-screen): bouton d’accès aux options avec popup

### DIFF
--- a/__tests__/MainScreen.test.tsx
+++ b/__tests__/MainScreen.test.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import App from '../App'; // point d’entrée
+import MainScreen from '../src/screens/MainScreen';
 
 describe('MainScreen', () => {
   it(`devrait afficher l'écran principal de Runova`, () => {
     const { getByTestId } = render(<App />);
     expect(getByTestId('main-screen')).toBeTruthy();
+  });
+
+  it(`devrait afficher une popup quand on appuie sur le bouton des options`, () => {
+    const { getByTestId, queryByText } = render(<MainScreen />);
+    expect(queryByText(/options.*bientôt/i)).toBeNull();
+
+    fireEvent.press(getByTestId('settings-button'));
+
+    expect(queryByText(/options.*bientôt/i)).toBeTruthy();
   });
 });

--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -1,10 +1,38 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Pressable, Modal } from 'react-native';
 
 const MainScreen = () => {
+  const [modalVisible, setModalVisible] = useState(false);
+
   return (
     <View style={styles.container} testID="main-screen">
+      {/* Bouton engrenage */}
+      <Pressable
+        onPress={() => setModalVisible(true)}
+        style={styles.settingsButton}
+        testID="settings-button"
+      >
+        <Text style={styles.settingsText}>⚙️</Text>
+      </Pressable>
+
       <Text style={styles.title}>Bienvenue sur Runova</Text>
+
+      {/* Modal */}
+      <Modal
+        visible={modalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalText}>L’écran des options arrivera bientôt.</Text>
+            <Pressable onPress={() => setModalVisible(false)} style={styles.closeButton}>
+              <Text style={styles.closeButtonText}>Fermer</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 };
@@ -13,13 +41,52 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#101010',
-    justifyContent: 'center',
-    alignItems: 'center',
+    paddingTop: 50,
+    paddingHorizontal: 20,
   },
   title: {
+    marginTop: 80,
     fontSize: 22,
     color: '#ffffff',
     fontWeight: '600',
+    alignSelf: 'center',
+  },
+  settingsButton: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    zIndex: 10,
+  },
+  settingsText: {
+    fontSize: 24,
+    color: '#fff',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: '#000000aa',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContent: {
+    backgroundColor: '#fff',
+    padding: 25,
+    borderRadius: 8,
+    minWidth: '70%',
+    alignItems: 'center',
+  },
+  modalText: {
+    fontSize: 16,
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+  closeButton: {
+    backgroundColor: '#101010',
+    paddingVertical: 8,
+    paddingHorizontal: 20,
+    borderRadius: 6,
+  },
+  closeButtonText: {
+    color: '#fff',
   },
 });
 


### PR DESCRIPTION
- Ajout d’un bouton ⚙️ en haut à droite de l’écran principal
- Affiche une popup native indiquant que l’écran des options arrive bientôt
- Implémentation testée en TDD
