### PR TITLE
feat(planning): planification de séances avec stockage en mémoire

### DIFF
--- a/__tests__/ScheduleRunPlanner.test.ts
+++ b/__tests__/ScheduleRunPlanner.test.ts
@@ -1,0 +1,27 @@
+import { ScheduledRun } from '../src/domain/models/ScheduledRun';
+import { RunStep } from '../src/domain/models/RunStep';
+import { RunStepType } from '../src/domain/models/RunStepType';
+import { InMemoryScheduledRunRepository } from '../src/infrastructure/repositories/InMemoryScheduledRunRepository';
+import { ScheduleRunPlanner } from '../src/application/usecases/ScheduleRunPlanner';
+
+describe('ScheduleRunPlanner', () => {
+  it('should create and store a scheduled run with steps', async () => {
+    const repo = new InMemoryScheduledRunRepository();
+    const planner = new ScheduleRunPlanner(repo);
+
+    const steps = [
+      new RunStep(RunStepType.Time, 15 * 60, { targetPace: '7:45' }),
+      new RunStep(RunStepType.Distance, 2000, { targetPace: '7:00' }),
+      new RunStep(RunStepType.Time, 10 * 60, { targetPace: '8:00' }),
+    ];
+
+    const run = new ScheduledRun('Sortie progressive', new Date('2025-06-02'), steps);
+
+    await planner.schedule(run);
+
+    const storedRuns = await repo.getAll();
+    expect(storedRuns.length).toBe(1);
+    expect(storedRuns[0].title).toBe('Sortie progressive');
+    expect(storedRuns[0].steps.length).toBe(3);
+  });
+});

--- a/src/application/usecases/ScheduleRunPlanner.ts
+++ b/src/application/usecases/ScheduleRunPlanner.ts
@@ -1,0 +1,10 @@
+import { ScheduledRun } from '../../domain/models/ScheduledRun';
+import { ScheduledRunRepository } from '../../domain/ports/ScheduledRunRepository';
+
+export class ScheduleRunPlanner {
+  constructor(private readonly repository: ScheduledRunRepository) {}
+
+  async schedule(run: ScheduledRun): Promise<void> {
+    await this.repository.save(run);
+  }
+}

--- a/src/domain/ports/ScheduledRunRepository.ts
+++ b/src/domain/ports/ScheduledRunRepository.ts
@@ -1,0 +1,6 @@
+import { ScheduledRun } from '../models/ScheduledRun';
+
+export interface ScheduledRunRepository {
+  save(run: ScheduledRun): Promise<void>;
+  getAll(): Promise<ScheduledRun[]>;
+}

--- a/src/infrastructure/repositories/InMemoryScheduledRunRepository.ts
+++ b/src/infrastructure/repositories/InMemoryScheduledRunRepository.ts
@@ -1,0 +1,14 @@
+import { ScheduledRun } from '../../domain/models/ScheduledRun';
+import { ScheduledRunRepository } from '../../domain/ports/ScheduledRunRepository';
+
+export class InMemoryScheduledRunRepository implements ScheduledRunRepository {
+  private runs: ScheduledRun[] = [];
+
+  async save(run: ScheduledRun): Promise<void> {
+    this.runs.push(run);
+  }
+
+  async getAll(): Promise<ScheduledRun[]> {
+    return this.runs;
+  }
+}


### PR DESCRIPTION
Ajout de la logique de planification d'une séance utilisateur :

- Création du use case `ScheduleRunPlanner`
- Définition du port `ScheduledRunRepository`
- Implémentation en mémoire avec `InMemoryScheduledRunRepository`
- Test unitaire de bout en bout vérifiant la création et le stockage d'une séance avec plusieurs étapes

Aucun backend pour l’instant, stockage local uniquement (TDD, archi hexagonale respectée).
