### PR TITLE
feat(run): affichage de l'étape en cours dans GuidedRunScreen avec bouton Démarrer

### DIFF
--- a/__tests__/GuidedRunScreen.test.tsx
+++ b/__tests__/GuidedRunScreen.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { GuidedRunScreen } from '../src/ui/screens/GuidedRunScreen';
+import { ScheduledRun } from '../src/domain/models/ScheduledRun';
+import { RunStep } from '../src/domain/models/RunStep';
+import { RunStepType } from '../src/domain/models/RunStepType';
+
+describe('GuidedRunScreen', () => {
+  it('should display the next step and start button', () => {
+    const steps = [
+      new RunStep(RunStepType.Time, 600, { targetPace: '7:45' }),
+      new RunStep(RunStepType.Distance, 1000, { targetPace: '6:30' }),
+    ];
+    const run = new ScheduledRun('Test Run', new Date(), steps);
+
+    render(<GuidedRunScreen run={run} />);
+
+    expect(screen.getByText('Étape 1')).toBeTruthy();
+    expect(screen.getByText('Durée : 10 min')).toBeTruthy();
+    expect(screen.getByText('Allure cible : 7:45/km')).toBeTruthy();
+    expect(screen.getByText('Démarrer')).toBeTruthy();
+
+    fireEvent.press(screen.getByText('Démarrer'));
+
+    expect(screen.queryByText('Démarrer')).toBeNull();
+  });
+});

--- a/src/ui/screens/GuidedRunScreen.tsx
+++ b/src/ui/screens/GuidedRunScreen.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { ScheduledRun } from '../../domain/models/ScheduledRun';
+
+type Props = {
+  run: ScheduledRun;
+};
+
+export const GuidedRunScreen: React.FC<Props> = ({ run }) => {
+  const [started, setStarted] = useState(false);
+  const step = run.steps[0];
+
+  return (
+    <View>
+      <Text>Étape 1</Text>
+      <Text>Durée : {step.value / 60} min</Text>
+      <Text>{`Allure cible : ${String(step.target.targetPace)}/km`}</Text>
+      {!started && <Button title="Démarrer" onPress={() => setStarted(true)} />}
+    </View>
+  );
+};


### PR DESCRIPTION
- Création de l'écran GuidedRunScreen
- Affichage de l'étape 1 d'une séance planifiée (durée/distance + allure)
- Bouton Démarrer visible au lancement, masqué après clic
- Test unitaire complet de l'écran
