### PR TITLE
feat(ui): création d'une course planifiée depuis l'interface

### DIFF
--- a/__tests__/ScheduledRunCreationScreen.test.tsx
+++ b/__tests__/ScheduledRunCreationScreen.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { ScheduledRunCreationScreen } from '../src/ui/screens/ScheduledRunCreationScreen';
+import { ScheduledRun } from '../src/domain/models/ScheduledRun';
+import { RunStep } from '../src/domain/models/RunStep';
+import { RunStepType } from '../src/domain/models/RunStepType';
+import { ScheduledRunRepository } from '../src/domain/ports/ScheduledRunRepository';
+
+class InMemoryTestRepo implements ScheduledRunRepository {
+  private stored: ScheduledRun[] = [];
+
+  async save(run: ScheduledRun): Promise<void> {
+    this.stored.push(run);
+  }
+
+  async getAll(): Promise<ScheduledRun[]> {
+    return this.stored;
+  }
+
+  getSavedRuns() {
+    return this.stored;
+  }
+}
+
+describe('ScheduledRunCreationScreen', () => {
+  it('should create a new scheduled run and call the repository', async () => {
+    const repo = new InMemoryTestRepo();
+    const onCreated = jest.fn();
+
+    render(<ScheduledRunCreationScreen repository={repo} onCreated={onCreated} />);
+
+    fireEvent.changeText(screen.getByPlaceholderText('Titre de la séance'), 'Test Run');
+    fireEvent.changeText(screen.getByPlaceholderText('Durée (en minutes)'), '10');
+    fireEvent.changeText(screen.getByPlaceholderText('Allure cible (min/km)'), '7:30');
+    fireEvent.press(screen.getByText('Valider'));
+
+    await waitFor(() => {
+      const runs = repo.getSavedRuns();
+      expect(runs.length).toBe(1);
+      expect(runs[0].title).toBe('Test Run');
+      expect(runs[0].steps[0]).toBeInstanceOf(RunStep);
+      expect(runs[0].steps[0].type).toBe(RunStepType.Time);
+      expect(runs[0].steps[0].target.targetPace).toBe('7:30');
+      expect(onCreated).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/ui/screens/ScheduledRunCreationScreen.tsx
+++ b/src/ui/screens/ScheduledRunCreationScreen.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { ScheduledRun } from '../../domain/models/ScheduledRun';
+import { RunStep } from '../../domain/models/RunStep';
+import { RunStepType } from '../../domain/models/RunStepType';
+import { ScheduledRunRepository } from '../../domain/ports/ScheduledRunRepository';
+
+type Props = {
+  repository: ScheduledRunRepository;
+  onCreated: () => void;
+};
+
+export const ScheduledRunCreationScreen: React.FC<Props> = ({ repository, onCreated }) => {
+  const [title, setTitle] = useState('');
+  const [duration, setDuration] = useState('');
+  const [pace, setPace] = useState('');
+
+  const handleSubmit = async () => {
+    const step = new RunStep(RunStepType.Time, parseInt(duration) * 60, {
+      targetPace: pace,
+    });
+
+    const run = new ScheduledRun(title, new Date(), [step]);
+    await repository.save(run);
+    onCreated();
+  };
+
+  return (
+    <View>
+      <TextInput placeholder="Titre de la séance" value={title} onChangeText={setTitle} />
+      <TextInput
+        placeholder="Durée (en minutes)"
+        keyboardType="numeric"
+        value={duration}
+        onChangeText={setDuration}
+      />
+      <TextInput placeholder="Allure cible (min/km)" value={pace} onChangeText={setPace} />
+      <Button title="Valider" onPress={handleSubmit} />
+    </View>
+  );
+};


### PR DESCRIPTION
- Ajout d'un écran ScheduledRunCreationScreen
- Saisie d'un titre, durée en minutes, et allure
- Création d'une ScheduledRun avec une étape simple (RunStepType.Time)
- Sauvegarde via le ScheduledRunRepository injecté
- Test unitaire complet avec repo mocké et validation du callback
